### PR TITLE
add/remove assurance attribute 

### DIFF
--- a/cca_utils/ldap3_utils.py
+++ b/cca_utils/ldap3_utils.py
@@ -277,6 +277,32 @@ def ldap_change_password(username, raw_password):
         raise
 
 
+def ldap_add_assurance(username, assurance):
+    dn = "uid={username},{ou}".format(username=username, ou=settings.LDAP_PEOPLE_OU)
+    mod_attrs = {}
+    mod_attrs['userPassword'] = [MODIFY_ADD, assurance]
+
+    try:
+        conn = ldap_connect()
+        conn.modify(dn, mod_attrs)
+        return True
+    except:
+        raise
+
+
+def ldap_remove_assurance(username, assurance):
+    dn = "uid={username},{ou}".format(username=username, ou=settings.LDAP_PEOPLE_OU)
+    mod_attrs = {}
+    mod_attrs['userPassword'] = [MODIFY_DELETE, assurance]
+
+    try:
+        conn = ldap_connect()
+        conn.modify(dn, mod_attrs)
+        return True
+    except:
+        raise
+
+
 def replace_user_entitlements(username, entitlements):
     '''
     Takes a username and a simple list of the "uid"s of entitlements,

--- a/cca_utils/ldap3_utils.py
+++ b/cca_utils/ldap3_utils.py
@@ -279,7 +279,6 @@ def ldap_change_password(username, raw_password):
 
 def ldap_add_assurance(username, assurance):
     dn = "uid={username},{ou}".format(username=username, ou=settings.LDAP_PEOPLE_OU)
-    mod_attrs = {}
     mod_attrs = {'eduPersonAssurance': [MODIFY_ADD, assurance]}
 
     conn = ldap_connect()
@@ -289,7 +288,6 @@ def ldap_add_assurance(username, assurance):
 
 def ldap_remove_assurance(username, assurance):
     dn = "uid={username},{ou}".format(username=username, ou=settings.LDAP_PEOPLE_OU)
-    mod_attrs = {}
     mod_attrs = {'eduPersonAssurance': [MODIFY_DELETE, assurance]}
 
     conn = ldap_connect()

--- a/cca_utils/ldap3_utils.py
+++ b/cca_utils/ldap3_utils.py
@@ -280,27 +280,21 @@ def ldap_change_password(username, raw_password):
 def ldap_add_assurance(username, assurance):
     dn = "uid={username},{ou}".format(username=username, ou=settings.LDAP_PEOPLE_OU)
     mod_attrs = {}
-    mod_attrs['userPassword'] = [MODIFY_ADD, assurance]
+    mod_attrs = {'eduPersonAssurance': [MODIFY_ADD, assurance]}
 
-    try:
-        conn = ldap_connect()
-        conn.modify(dn, mod_attrs)
-        return True
-    except:
-        raise
+    conn = ldap_connect()
+    conn.modify(dn, mod_attrs)
+    return True
 
 
 def ldap_remove_assurance(username, assurance):
     dn = "uid={username},{ou}".format(username=username, ou=settings.LDAP_PEOPLE_OU)
     mod_attrs = {}
-    mod_attrs['userPassword'] = [MODIFY_DELETE, assurance]
+    mod_attrs = {'eduPersonAssurance': [MODIFY_DELETE, assurance]}
 
-    try:
-        conn = ldap_connect()
-        conn.modify(dn, mod_attrs)
-        return True
-    except:
-        raise
+    conn = ldap_connect()
+    conn.modify(dn, mod_attrs)
+    return True
 
 
 def replace_user_entitlements(username, entitlements):

--- a/cca_utils/ldap_utils.py
+++ b/cca_utils/ldap_utils.py
@@ -608,7 +608,40 @@ def ldap_change_password(username, raw_password):
         raise
 
 
-def convert_group_member_uid(ldapgroup):
+def ldap_add_assurance(username, assurance):
+    dn = "uid={username},{ou}".format(username=username, ou=settings.LDAP_PEOPLE_OU)
+    conn = ldap_connect(modify=True)
+    mod_attrs = [(ldap.MOD_ADD, 'eduPersonAssurance', assurance)]
+
+    try:
+        conn.modify_s(dn, mod_attrs)
+        return True
+    except:
+        raise
+
+
+def ldap_remove_assurance(username, assurance):
+    dn = "uid={username},{ou}".format(username=username, ou=settings.LDAP_PEOPLE_OU)
+    conn = ldap_connect(modify=True)
+    mod_attrs = [(ldap.MOD_DELETE, 'eduPersonAssurance', assurance)]
+
+    try:
+        conn.modify_s(dn, mod_attrs)
+        return True
+    except:
+        raise
+
+def ldap_get_assurance(username):
+    '''
+    Retrieve user eduPersonAssurance
+    '''
+    data = ldap_get_user_data(username)
+    if 'eduPersonAssurance' in data:
+        assurance = data["eduPersonAssurance"][0]
+        return assurance
+
+
+def  convert_group_member_uid(ldapgroup):
     '''
     Takes the LDAP group member string (full LDAP DN) and returns a list of UIDs
     '''

--- a/cca_utils/ldap_utils.py
+++ b/cca_utils/ldap_utils.py
@@ -612,24 +612,16 @@ def ldap_add_assurance(username, assurance):
     dn = "uid={username},{ou}".format(username=username, ou=settings.LDAP_PEOPLE_OU)
     conn = ldap_connect(modify=True)
     mod_attrs = [(ldap.MOD_ADD, 'eduPersonAssurance', assurance)]
-
-    try:
-        conn.modify_s(dn, mod_attrs)
-        return True
-    except:
-        raise
+    conn.modify_s(dn, mod_attrs)
+    return True
 
 
 def ldap_remove_assurance(username, assurance):
     dn = "uid={username},{ou}".format(username=username, ou=settings.LDAP_PEOPLE_OU)
     conn = ldap_connect(modify=True)
     mod_attrs = [(ldap.MOD_DELETE, 'eduPersonAssurance', assurance)]
-
-    try:
-        conn.modify_s(dn, mod_attrs)
-        return True
-    except:
-        raise
+    conn.modify_s(dn, mod_attrs)
+    return True
 
 def ldap_get_assurance(username):
     '''


### PR DESCRIPTION
function to add/remove eduPersonAssurance to LDAP utils. This is used for SSO enforcement via LDAP.